### PR TITLE
Use correct repo and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Backport closed pull request
     steps:
-      - uses: sbrunner/backport-action@v1
+      - uses: sbrunner/backport-action@v1.0.0
         with:
           token: ${{ secrets.BACKPORT_GITHUB_TOKEN }}
 ```


### PR DESCRIPTION
Use the correct repository camptocamp.
Use v1.0.0 instead of v1 to target the version because the latter does not work.