### PR TITLE
Install git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM camptocamp/python-action
 
+RUN \
+  apt-get update && \
+  apt-get install --assume-yes --no-install-recommends git && \
+  apt-get clean && \
+  rm --recursive --force /var/lib/apt/lists/
+
 COPY backport /usr/bin/backport
 
 ENTRYPOINT ["backport"]


### PR DESCRIPTION
Since camptocamp/python-action base image has been updated to ubuntu:22.04,
it seems that we do not have git anymore.